### PR TITLE
Readme: Fix JS syntax highlighting

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Formous strives to be a _simple_, elegant solution to handling forms in React. F
 
 Use the code snippet below as an example to help you get started right away.
 
-```jsx
+```js
 import React, { Component } from 'react';
 import Formous from 'formous';
 


### PR DESCRIPTION
Just a small fix. GitHub markdown doesn't recognise `jsx` as syntax.