### PR TITLE
Fixed the code sample in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ class MyComponent extends Component {
 const formousOptions = {
   fields: {
     name: {
+      name: 'name',
       tests: [
         {
           critical: true,
@@ -104,6 +105,7 @@ const formousOptions = {
     },
 
     age: {
+      name: 'age',
       tests: [
         {
           critical: true,


### PR DESCRIPTION
Just fix the code sample of the Quick Start section.
With v0.8.0, it seems that the name property is required.

:)