### PR TITLE
use a single setState for setting defaults for defaults to be set on first render

### DIFF
--- a/lib/formous.js
+++ b/lib/formous.js
@@ -113,9 +113,9 @@ var Formous = function Formous(options) {
         }
       }, {
         key: 'isFormValid',
-        value: function isFormValid(options) {
+        value: function isFormValid(fields, options) {
           var excludeField = options && options.excludeField;
-          var stateFields = this.state.fields.toJS();
+          var stateFields = fields.toJS();
           var examineFields = Object.keys(stateFields).filter(function (fieldName) {
             return fieldName !== excludeField;
           });
@@ -172,8 +172,6 @@ var Formous = function Formous(options) {
       }, {
         key: 'setDefaultValues',
         value: function setDefaultValues(defaultData) {
-          var _this3 = this;
-
           if (!this.defaultsSet) {
             var defaults = {};
 
@@ -194,14 +192,13 @@ var Formous = function Formous(options) {
               };
             }
 
+            var fields = this.state.fields.mergeDeep(defaults);
+
             this.setState({
-              fields: this.state.fields.mergeDeep(defaults)
-            }, function () {
-              _this3.setState({
-                form: _extends({}, _this3.state.form, {
-                  valid: _this3.isFormValid()
-                })
-              });
+              fields: fields,
+              form: _extends({}, this.state.form, {
+                valid: this.isFormValid(fields)
+              })
             });
 
             this.defaultsSet = true;
@@ -253,14 +250,14 @@ var Formous = function Formous(options) {
         value: function setFormValidity() {
           this.setState({
             form: _extends({}, this.state.form, {
-              valid: this.isFormValid()
+              valid: this.isFormValid(this.state.fields)
             })
           });
         }
       }, {
         key: 'testField',
         value: function testField(fieldSpec, value, initial) {
-          var _this4 = this;
+          var _this3 = this;
 
           var tests = fieldSpec.tests;
           var completedTests = [];
@@ -305,8 +302,8 @@ var Formous = function Formous(options) {
           if (fieldSpec.alsoTest && !initial && failedTestCount === 0) {
             fieldSpec.alsoTest.forEach(function (fieldName) {
               var fieldInfo = options.fields[fieldName];
-              var fieldValue = _this4.state.fields.getIn([fieldName, 'value']);
-              var sideEffectTests = _this4.testField(fieldInfo, fieldValue);
+              var fieldValue = _this3.state.fields.getIn([fieldName, 'value']);
+              var sideEffectTests = _this3.testField(fieldInfo, fieldValue);
 
               sideEffectTests = sideEffectTests.map(function (test) {
                 return _extends({}, test, { quiet: true });

--- a/src/formous.js
+++ b/src/formous.js
@@ -85,9 +85,9 @@ const Formous = (options: Object): ReactClass => {
       }
     }
 
-    isFormValid(options: ?{ excludeField: string }): boolean {
+    isFormValid(fields: Object, options: ?{ excludeField: string }): boolean {
       const excludeField: ?string = options && options.excludeField;
-      const stateFields: Object = this.state.fields.toJS();
+      const stateFields: Object = fields.toJS();
       const examineFields: Array<string> = Object.keys(stateFields)
         .filter((fieldName: string) => fieldName !== excludeField);
 
@@ -173,15 +173,14 @@ const Formous = (options: Object): ReactClass => {
           };
         }
 
+        const fields = this.state.fields.mergeDeep(defaults);
+
         this.setState({
-          fields: this.state.fields.mergeDeep(defaults),
-        }, () => {
-          this.setState({
-            form: {
-              ...this.state.form,
-              valid: this.isFormValid(),
-            },
-          });
+          fields,
+          form: {
+            ...this.state.form,
+            valid: this.isFormValid(fields),
+          },
         });
 
         this.defaultsSet = true;
@@ -217,7 +216,7 @@ const Formous = (options: Object): ReactClass => {
       this.setState({
         form: {
           ...this.state.form,
-          valid: this.isFormValid(),
+          valid: this.isFormValid(this.state.fields),
         },
       });
     }


### PR DESCRIPTION
related to #10 

I believe the setState can be combined to a single setState (allowing for defaults to be set on the first render).

this changes the `isFormValid` signature to accept fields rather than reading fields from state. I looked around and didn't see it being called with options.