### PR TITLE
use only single setState for form validity

### DIFF
--- a/lib/formous.js
+++ b/lib/formous.js
@@ -95,9 +95,14 @@ var Formous = function Formous(options) {
             };
           }
 
+          var fields = (0, _immutable.fromJS)(updatedFields);
+
           this.setState({
-            fields: (0, _immutable.fromJS)(updatedFields)
-          }, this.setFormValidity);
+            fields: fields,
+            form: _extends({}, this.state.form, {
+              valid: this.isFormValid(fields)
+            })
+          });
         }
       }, {
         key: 'formSubmit',
@@ -135,12 +140,17 @@ var Formous = function Formous(options) {
       }, {
         key: 'markFieldAsValid',
         value: function markFieldAsValid(fieldName, valid, options) {
+          var fields = this.state.fields.mergeDeep(_defineProperty({}, fieldName, {
+            failProps: options.quietly ? undefined : options.failProps,
+            valid: valid
+          }));
+
           this.setState({
-            fields: this.state.fields.mergeDeep(_defineProperty({}, fieldName, {
-              failProps: options.quietly ? undefined : options.failProps,
-              valid: valid
-            }))
-          }, this.setFormValidity);
+            fields: fields,
+            form: _extends({}, this.state.form, {
+              valid: this.isFormValid(fields)
+            })
+          });
         }
       }, {
         key: 'onBlur',
@@ -163,11 +173,13 @@ var Formous = function Formous(options) {
       }, {
         key: 'onFocus',
         value: function onFocus() {
-          this.setState({
-            form: _extends({}, this.state.form, {
-              touched: true
-            })
-          });
+          if (!this.state.form.touched) {
+            this.setState({
+              form: _extends({}, this.state.form, {
+                touched: true
+              })
+            });
+          }
         }
       }, {
         key: 'setDefaultValues',
@@ -240,19 +252,15 @@ var Formous = function Formous(options) {
               }
             }
 
+            var fields = this.state.fields.mergeDeep(updatedFields);
+
             this.setState({
-              fields: this.state.fields.mergeDeep(_extends({}, updatedFields))
-            }, this.setFormValidity);
+              fields: fields,
+              form: _extends({}, this.state.form, {
+                valid: this.isFormValid(fields)
+              })
+            });
           }
-        }
-      }, {
-        key: 'setFormValidity',
-        value: function setFormValidity() {
-          this.setState({
-            form: _extends({}, this.state.form, {
-              valid: this.isFormValid(this.state.fields)
-            })
-          });
         }
       }, {
         key: 'testField',

--- a/src/formous.js
+++ b/src/formous.js
@@ -69,9 +69,15 @@ const Formous = (options: Object): ReactClass => {
         };
       }
 
+      const fields = fromJS(updatedFields);
+
       this.setState({
-        fields: fromJS(updatedFields),
-      }, this.setFormValidity);
+        fields,
+        form: {
+          ...this.state.form,
+          valid: this.isFormValid(fields),
+        },
+      });
     }
 
     formSubmit(formHandler: Function): Function {
@@ -111,14 +117,20 @@ const Formous = (options: Object): ReactClass => {
       failProps: ?Object,
       quietly: boolean,
     }) {
+      const fields = this.state.fields.mergeDeep({
+        [fieldName]: {
+          failProps: options.quietly ? undefined : options.failProps,
+          valid,
+        },
+      });
+
       this.setState({
-        fields: this.state.fields.mergeDeep({
-          [fieldName]: {
-            failProps: options.quietly ? undefined : options.failProps,
-            valid,
-          },
-        }),
-      }, this.setFormValidity);
+        fields,
+        form: {
+          ...this.state.form,
+          valid: this.isFormValid(fields),
+        },
+      });
     }
 
     onBlur(fieldSpec: Object, { target }: Object) {
@@ -142,12 +154,14 @@ const Formous = (options: Object): ReactClass => {
     }
 
     onFocus() {
-      this.setState({
-        form: {
-          ...this.state.form,
-          touched: true,
-        },
-      });
+      if (!this.state.form.touched) {
+        this.setState({
+          form: {
+            ...this.state.form,
+            touched: true,
+          },
+        });
+      }
     }
 
     setDefaultValues(defaultData: Object) {
@@ -204,21 +218,16 @@ const Formous = (options: Object): ReactClass => {
           };
         }
 
-        this.setState({
-          fields: this.state.fields.mergeDeep({
-            ...updatedFields,
-          }),
-        }, this.setFormValidity);
-      }
-    }
+        const fields = this.state.fields.mergeDeep(updatedFields);
 
-    setFormValidity() {
-      this.setState({
-        form: {
-          ...this.state.form,
-          valid: this.isFormValid(this.state.fields),
-        },
-      });
+        this.setState({
+          fields,
+          form: {
+            ...this.state.form,
+            valid: this.isFormValid(fields),
+          },
+        });
+      }
     }
 
     // Returns all tests that were run


### PR DESCRIPTION
- remove more of the setState callbacks to a single setState
- onFocus only setState if touched was false before
