### PR TITLE
updateFields change state once

### DIFF
--- a/lib/formous.js
+++ b/lib/formous.js
@@ -254,15 +254,14 @@ var Formous = function Formous(options) {
 
         _this.updateFields = function (fields) {
           _this.setState({
-            fields: fields
-          }, _this.updateFormValidity);
+            fields: fields,
+            form: _this.updateFormValidity(fields)
+          });
         };
 
-        _this.updateFormValidity = function () {
-          _this.setState({
-            form: _extends({}, _this.state.form, {
-              valid: _this.isFormValid(_this.state.fields)
-            })
+        _this.updateFormValidity = function (fields) {
+          return _extends({}, _this.state.form, {
+            valid: _this.isFormValid(fields)
           });
         };
 

--- a/src/formous.js
+++ b/src/formous.js
@@ -282,19 +282,18 @@ const Formous = (options: Object): ReactClass<*> => {
     updateFields = (fields: Object) => {
       this.setState({
         fields,
-      }, this.updateFormValidity);
+        form: this.updateFormValidity(fields),
+      });
     };
 
     /*
-     * Updates the form validity based on the current field values (in state).
+     * Returns an updated form state.
      */
-    updateFormValidity = () => {
-      this.setState({
-        form: {
-          ...this.state.form,
-          valid: this.isFormValid(this.state.fields),
-        },
-      });
+    updateFormValidity = (fields: Object) => {
+      return {
+        ...this.state.form,
+        valid: this.isFormValid(fields),
+      };
     };
 
     render() {


### PR DESCRIPTION
Changes `updateFormValidity` to return the updated form value and `updateFields` updates state with the new form state.

This way the wrapped component will render once with the correct form status.